### PR TITLE
Pin qt dependency to Qt5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 os: osx
+osx_image: xcode12.2
 env:
   matrix:
     - FORMULA_VERSION=

--- a/neovim-qt.rb
+++ b/neovim-qt.rb
@@ -6,7 +6,7 @@ class NeovimQt < Formula
   head "https://github.com/equalsraf/neovim-qt.git"
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "neovim"
 
   def install


### PR DESCRIPTION
With the release of Qt6 the recipe is not working anymore. Pin
dependency to qt5.

The CI builds were already failing, still need to look into that

ref https://github.com/equalsraf/homebrew-neovim-qt/issues/3